### PR TITLE
fix header row's height doesn't update on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- fix: header row's height doesn't update on `headerHeight` change
+
 ## v1.0.0 (2019-03-26)
 
 Initial public release

--- a/src/GridTable.js
+++ b/src/GridTable.js
@@ -4,6 +4,7 @@ import cn from 'classnames';
 import Grid from 'react-virtualized/dist/commonjs/Grid';
 
 import cellRangeRenderer from './cellRangeRenderer';
+import { isObjectEqual } from './utils';
 
 /**
  * A wrapper of the Grid for internal only
@@ -141,6 +142,16 @@ class GridTable extends React.PureComponent {
         )}
       </div>
     );
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      !isObjectEqual(this.props.headerHeight, prevProps.headerHeight) ||
+      // if there are frozen rows
+      this.props.rowHeight !== prevProps.rowHeight
+    ) {
+      this.headerRef && this.headerRef.recomputeGridSize();
+    }
   }
 
   _setHeaderRef(ref) {


### PR DESCRIPTION
`rowHeight` for header `Grid` is a function https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md#recomputegridsize--columnindex-number-rowindex-number-