### PR TITLE
spread headerCellProps into cellProps to use them

### DIFF
--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -353,7 +353,7 @@ class BaseTable extends React.PureComponent {
     const TableHeaderCell = this._getComponent('TableHeaderCell');
     const SortIndicator = this._getComponent('SortIndicator');
 
-    const cellProps = { columns, column, columnIndex, headerIndex, container: this };
+    const cellProps = { ...headerCellProps, columns, column, columnIndex, headerIndex, container: this };
     const cell = renderElement(
       headerRenderer || <TableHeaderCell className={this._prefixClass('header-cell-text')} />,
       cellProps


### PR DESCRIPTION
I think headerCellProps would be useful to make headerCell. I tried to pass a variable without touching my column object, it's not possible right now.

I think it would be nice to pass all cellProps to cell functions.