### PR TITLE
refactor: remove dependency on react-dragable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- refactor: remove dependent on `react-draggable`
+
 ## v1.4.0 (2019-07-01)
 
 - refactor: remove dependent on `lodash`, and export `getValue`

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "classnames": "^2.2.5",
     "memoize-one": "^5.0.0",
     "prop-types": "^15.7.0",
-    "react-draggable": "^3.0.5",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.2"
   },

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -395,7 +395,6 @@ class BaseTable extends React.PureComponent {
         {column.resizable && (
           <ColumnResizer
             className={this._prefixClass('column-resizer')}
-            handleClassName={this._prefixClass('column-resizer-handle')}
             column={column}
             onResizeStart={this._handleColumnResizeStart}
             onResizeStop={this._handleColumnResizeStop}
@@ -524,8 +523,6 @@ class BaseTable extends React.PureComponent {
     }
     const style = {
       left,
-      width: 3,
-      transform: 'translateX(-3px)',
       height: this._getTableHeight() - this._horizontalScrollbarSize,
     };
     return <div className={this._prefixClass('resizing-line')} style={style} />;

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -25,6 +25,7 @@ import {
   flattenOnKeys,
   cloneArray,
   getValue,
+  throttle,
   noop,
 } from './utils';
 
@@ -41,6 +42,8 @@ const DEFAULT_COMPONENTS = {
   ExpandIcon,
   SortIndicator,
 };
+
+const RESIZE_THROTTLE_WAIT = 50;
 
 /**
  * React table component
@@ -74,7 +77,7 @@ class BaseTable extends React.PureComponent {
     this._handleRowsRendered = this._handleRowsRendered.bind(this);
     this._handleRowHover = this._handleRowHover.bind(this);
     this._handleRowExpand = this._handleRowExpand.bind(this);
-    this._handleColumnResize = this._handleColumnResize.bind(this);
+    this._handleColumnResize = throttle(this._handleColumnResize.bind(this), RESIZE_THROTTLE_WAIT);
     this._handleColumnResizeStart = this._handleColumnResizeStart.bind(this);
     this._handleColumnResizeStop = this._handleColumnResizeStop.bind(this);
     this._handleColumnSort = this._handleColumnSort.bind(this);

--- a/src/ColumnResizer.js
+++ b/src/ColumnResizer.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { noop, throttle } from './utils';
+import { noop } from './utils';
 
 const INVALID_VALUE = null;
-const MIN_WIDTH = 30;
-const THROTTLE_WAIT = 50;
 
 /**
  * ColumnResizer for BaseTable
@@ -22,7 +20,7 @@ class ColumnResizer extends React.PureComponent {
     this._handleClick = this._handleClick.bind(this);
     this._handleMouseDown = this._handleMouseDown.bind(this);
     this._handleMouseUp = this._handleMouseUp.bind(this);
-    this._handleMouseMove = throttle(this._handleMouseMove.bind(this), THROTTLE_WAIT);
+    this._handleMouseMove = this._handleMouseMove.bind(this);
   }
 
   componentWillMount() {
@@ -99,7 +97,7 @@ class ColumnResizer extends React.PureComponent {
       return;
     }
 
-    const { column } = this.props;
+    const { column, minWidth: MIN_WIDTH } = this.props;
     const { width, maxWidth, minWidth = MIN_WIDTH } = column;
     const movedX = x - this.lastX;
     if (!movedX) return;
@@ -123,6 +121,7 @@ ColumnResizer.defaultProps = {
   onResizeStart: noop,
   onResize: noop,
   onResizeStop: noop,
+  minWidth: 30,
 };
 
 ColumnResizer.propTypes = {
@@ -149,6 +148,10 @@ ColumnResizer.propTypes = {
    * The callback is of the shape of `(column) => *`
    */
   onResizeStop: PropTypes.func,
+  /**
+   * Minimum width of the column could be resized to if the column's `minWidth` is not set
+   */
+  minWidth: PropTypes.number,
 };
 
 export default ColumnResizer;

--- a/src/ColumnResizer.js
+++ b/src/ColumnResizer.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cn from 'classnames';
-import { DraggableCore } from 'react-draggable';
 
 import { noop, throttle } from './utils';
 
 const INVALID_VALUE = null;
-const MIN_WIDTH = 25;
+const MIN_WIDTH = 30;
 const THROTTLE_WAIT = 50;
 
 /**
@@ -16,58 +14,98 @@ class ColumnResizer extends React.PureComponent {
   constructor(props) {
     super(props);
 
+    this.isDragging = false;
     this.lastX = INVALID_VALUE;
     this.width = 0;
 
-    this._handleDrag = throttle(this._handleDrag.bind(this), THROTTLE_WAIT);
-    this._handleStart = this._handleStart.bind(this);
-    this._handleStop = this._handleStop.bind(this);
+    this._setHandleRef = this._setHandleRef.bind(this);
     this._handleClick = this._handleClick.bind(this);
+    this._handleMouseDown = this._handleMouseDown.bind(this);
+    this._handleMouseUp = this._handleMouseUp.bind(this);
+    this._handleMouseMove = throttle(this._handleMouseMove.bind(this), THROTTLE_WAIT);
+  }
+
+  componentWillMount() {
+    if (this.handleRef) {
+      const { ownerDocument } = this.handleRef;
+      ownerDocument.removeEventListener('mousemove', this._handleMouseMove);
+      ownerDocument.addEventListener('mouseup', this._handleMouseUp);
+    }
   }
 
   render() {
-    const { className, style, width, disabled } = this.props;
+    const { style, column, onResizeStart, onResize, onResizeStop, ...rest } = this.props;
 
-    const cls = cn('BaseTable__column-resizer', className);
     return (
-      <DraggableCore
-        axis="x"
-        disabled={disabled}
-        onStart={this._handleStart}
-        onDrag={this._handleDrag}
-        onStop={this._handleStop}
-      >
-        <div
-          className={cls}
-          onClick={this._handleClick}
-          style={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            right: 0,
-            cursor: 'ew-resize',
-            borderRightStyle: 'solid',
-            ...style,
-            borderRightWidth: width,
-          }}
-        />
-      </DraggableCore>
+      <div
+        {...rest}
+        ref={this._setHandleRef}
+        onClick={this._handleClick}
+        onMouseDown={this._handleMouseDown}
+        onMouseUp={this._handleMouseUp}
+        style={{
+          userSelect: 'none',
+          touchAction: 'none',
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          right: 0,
+          cursor: 'col-resize',
+          ...style,
+        }}
+      />
     );
   }
 
-  _handleDrag(e, data) {
+  _setHandleRef(ref) {
+    this.handleRef = ref;
+  }
+
+  _handleClick(e) {
+    e.stopPropagation();
+  }
+
+  _handleMouseDown(e) {
+    if (typeof e.button === 'number' && e.button !== 0) return;
+
+    this.isDragging = true;
+    this.lastX = INVALID_VALUE;
+    this.width = this.props.column.width;
+    this.props.onResizeStart(this.props.column);
+
+    const { ownerDocument } = this.handleRef;
+    ownerDocument.addEventListener('mousemove', this._handleMouseMove);
+    ownerDocument.addEventListener('mouseup', this._handleMouseUp);
+  }
+
+  _handleMouseUp(e) {
+    if (!this.isDragging) return;
+    this.isDragging = false;
+
+    this.props.onResizeStop(this.props.column);
+
+    const { ownerDocument } = this.handleRef;
+    ownerDocument.removeEventListener('mousemove', this._handleMouseMove);
+    ownerDocument.addEventListener('mouseup', this._handleMouseUp);
+  }
+
+  _handleMouseMove(e) {
+    const { offsetParent } = this.handleRef;
+    const offsetParentRect = offsetParent.getBoundingClientRect();
+    const x = e.clientX + offsetParent.scrollLeft - offsetParentRect.left;
+
     if (this.lastX === INVALID_VALUE) {
-      this.lastX = data.lastX;
-      return true;
+      this.lastX = x;
+      return;
     }
 
     const { column } = this.props;
     const { width, maxWidth, minWidth = MIN_WIDTH } = column;
-    const movedX = data.x - this.lastX;
-    if (!movedX) return true;
+    const movedX = x - this.lastX;
+    if (!movedX) return;
 
     this.width = this.width + movedX;
-    this.lastX = data.x;
+    this.lastX = x;
 
     let newWidth = this.width;
     if (maxWidth && newWidth > maxWidth) {
@@ -76,27 +114,12 @@ class ColumnResizer extends React.PureComponent {
       newWidth = minWidth;
     }
 
-    if (newWidth === width) return true;
-    return this.props.onResize(column, newWidth);
-  }
-
-  _handleStart(e, data) {
-    this.lastX = INVALID_VALUE;
-    this.width = this.props.column.width;
-    return this.props.onResizeStart(this.props.column);
-  }
-
-  _handleStop(e, data) {
-    return this.props.onResizeStop(this.props.column);
-  }
-
-  _handleClick(e) {
-    e.stopPropagation();
+    if (newWidth === width) return;
+    this.props.onResize(column, newWidth);
   }
 }
 
 ColumnResizer.defaultProps = {
-  width: 3,
   onResizeStart: noop,
   onResize: noop,
   onResizeStop: noop,
@@ -104,25 +127,13 @@ ColumnResizer.defaultProps = {
 
 ColumnResizer.propTypes = {
   /**
-   * Class name for the drag handler
+   * Custom style for the drag handler
    */
-  className: PropTypes.string,
+  style: PropTypes.object,
   /**
    * The column object to be dragged
    */
   column: PropTypes.object,
-  /**
-   * The width of the drag handler
-   */
-  width: PropTypes.number.isRequired,
-  /**
-   * Whether the resizing is disabled
-   */
-  disabled: PropTypes.bool,
-  /**
-   * Custom style for the drag handler
-   */
-  style: PropTypes.object,
   /**
    * A callback function when resizing started
    * The callback is of the shape of `(column) => *`

--- a/src/_BaseTable.scss
+++ b/src/_BaseTable.scss
@@ -199,6 +199,17 @@ $table-prefix: BaseTable !default;
     position: relative;
     cursor: default;
 
+    &:hover {
+      .#{$table-prefix}__column-resizer {
+        visibility: visible;
+        opacity: 0.5;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+    }
+
     .#{$table-prefix}__sort-indicator {
       display: none;
     }
@@ -223,9 +234,14 @@ $table-prefix: BaseTable !default;
 
     &--resizing {
       .#{$table-prefix}__column-resizer {
+        visibility: visible;
+        opacity: 1;
         // workaround to prevent header being clicked when resizing stopped on header
-        padding-left: 999px;
-        border-color: $column-resizer-color;
+        &::after {
+          @include fill-layout();
+          content: '';
+          left: -9999px;
+        }
       }
     }
 
@@ -239,7 +255,7 @@ $table-prefix: BaseTable !default;
   &__header-row--resizing {
     .#{$table-prefix}__header-cell {
       background-color: transparent;
-      cursor: ew-resize;
+      cursor: col-resize;
 
       &:not(.#{$table-prefix}__header-cell--sorting) {
         .#{$table-prefix}__sort-indicator {
@@ -249,17 +265,20 @@ $table-prefix: BaseTable !default;
 
       &:not(.#{$table-prefix}__header-cell--resizing) {
         .#{$table-prefix}__column-resizer {
-          border-color: transparent;
+          visibility: hidden;
         }
       }
     }
   }
 
   &__column-resizer {
-    border-color: transparent;
+    width: 3px;
+    visibility: hidden;
+    background-color: $column-resizer-color;
 
     &:hover {
-      border-color: $column-resizer-color;
+      visibility: visible;
+      opacity: 1;
     }
   }
 
@@ -269,10 +288,12 @@ $table-prefix: BaseTable !default;
   }
 
   &__resizing-line {
-    cursor: ew-resize;
+    cursor: col-resize;
     position: absolute;
     top: 0;
     background-color: $column-resizer-color;
+    width: 3px;
+    transform: translateX(-100%);
   }
 
   &__empty-layer {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6518,7 +6518,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6632,14 +6632,6 @@ react-dom@^16.4.2:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
-
-react-draggable@^3.0.5:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.3.0.tgz#2ed7ea3f92e7d742d747f9e6324860606cd4d997"
-  integrity sha512-U7/jD0tAW4T0S7DCPK0kkKLyL0z61sC/eqU+NUfDjnq+JtBKaYKDHpsK2wazctiA4alEzCXUnzkREoxppOySVw==
-  dependencies:
-    classnames "^2.2.5"
-    prop-types "^15.6.0"
 
 react-is@^16.8.1, react-is@^16.8.6:
   version "16.8.6"


### PR DESCRIPTION
ref https://github.com/Autodesk/react-base-table/issues/3#issuecomment-493711970

currently `react-draggble` takes 1/5 of the bundle size
![image](https://user-images.githubusercontent.com/2595058/60735210-054e6000-9f85-11e9-9fed-898414b44710.png)

@zmitry FYI