### PR TITLE
getValue returns the object itself if the path is not valid string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- fix: `getValue` returns the object itself if the path is not valid string
+
 ## v1.6.1 (2019-07-06)
 
 - feat: support infinite loading with `maxHeight` 

--- a/src/utils.js
+++ b/src/utils.js
@@ -140,10 +140,10 @@ function getPathSegments(path) {
   return parts;
 }
 
-// copied from https://github.com/sindresorhus/dot-prop/blob/master/index.js
+// changed from https://github.com/sindresorhus/dot-prop/blob/master/index.js
 export function getValue(object, path, defaultValue) {
   if (object === null || typeof object !== 'object' || typeof path !== 'string') {
-    return defaultValue === undefined ? object : defaultValue;
+    return defaultValue;
   }
 
   const pathArray = getPathSegments(path);


### PR DESCRIPTION
that's a regression from #54 which use `dot-prop` to replace `lodash.get`, but `dot-prop` just return the object itself if the path is not valid string
![image](https://user-images.githubusercontent.com/2595058/60769320-d3620880-a100-11e9-9c87-c0aa43177cd8.png)
