### PR TITLE
fix regression of scrollToRow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- fix: `scrollToRow` doesn't work regression introduced in #73
+
 ## v1.7.0 (2019-08-06)
 
 - chore: remove the use of `Object.values`

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -208,10 +208,19 @@ class BaseTable extends React.PureComponent {
    * @param {string} align
    */
   scrollToRow(rowIndex = 0, align = 'auto') {
-    this.table && this.table.scrollToRow(rowIndex, align);
-    this.leftTable && this.leftTable.scrollToRow(rowIndex, align);
-    this.rightTable && this.rightTable.scrollToRow(rowIndex, align);
-    this.scrollToLeft(0);
+    // if the table is in `fixed` mode, it could be scrolled horizontally, in that case,
+    // the horizontal scroll position would be unexpected if the `align` is not `start`,
+    // so we reset the horizontal scroll to the previous value in that case,
+    // and the two scroll methods would be batched on event callback, and the `onScroll` event will be called after that,
+    // then it will be reset to the original position as the `this._scroll` is not synced to the new state,
+    // so we put them in a `setTimeout` to make `onScroll` be called before we set the horizontal position.
+    setTimeout(() => {
+      const prevScrollLeft = this._scroll.scrollLeft;
+      this.table && this.table.scrollToRow(rowIndex, align);
+      this.leftTable && this.leftTable.scrollToRow(rowIndex, align);
+      this.rightTable && this.rightTable.scrollToRow(rowIndex, align);
+      this.props.fixed && this.scrollToLeft(prevScrollLeft);
+    }, 0);
   }
 
   /**

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -208,19 +208,9 @@ class BaseTable extends React.PureComponent {
    * @param {string} align
    */
   scrollToRow(rowIndex = 0, align = 'auto') {
-    // if the table is in `fixed` mode, it could be scrolled horizontally, in that case,
-    // the horizontal scroll position would be unexpected if the `align` is not `start`,
-    // so we reset the horizontal scroll to the previous value in that case,
-    // and the two scroll methods would be batched on event callback, and the `onScroll` event will be called after that,
-    // then it will be reset to the original position as the `this._scroll` is not synced to the new state,
-    // so we put them in a `setTimeout` to make `onScroll` be called before we set the horizontal position.
-    setTimeout(() => {
-      const prevScrollLeft = this._scroll.scrollLeft;
-      this.table && this.table.scrollToRow(rowIndex, align);
-      this.leftTable && this.leftTable.scrollToRow(rowIndex, align);
-      this.rightTable && this.rightTable.scrollToRow(rowIndex, align);
-      this.props.fixed && this.scrollToLeft(prevScrollLeft);
-    }, 0);
+    this.table && this.table.scrollToRow(rowIndex, align);
+    this.leftTable && this.leftTable.scrollToRow(rowIndex, align);
+    this.rightTable && this.rightTable.scrollToRow(rowIndex, align);
   }
 
   /**

--- a/src/GridTable.js
+++ b/src/GridTable.js
@@ -40,7 +40,7 @@ class GridTable extends React.PureComponent {
   }
 
   scrollToRow(rowIndex = 0, align = 'auto') {
-    this.bodyRef && this.bodyRef.scrollToItem({ rowIndex, columnIndex: 0, align });
+    this.bodyRef && this.bodyRef.scrollToItem({ rowIndex, align });
   }
 
   renderRow(args) {

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -204,5 +204,9 @@ module.exports = {
       title: 'Inline Editing',
       path: '/examples/inline-editing',
     },
+    {
+      title: 'Scroll Methods',
+      path: '/examples/scroll-to',
+    },
   ],
 }

--- a/website/src/examples/scroll-to.js
+++ b/website/src/examples/scroll-to.js
@@ -7,17 +7,14 @@ const Button = styled.button`
 `
 
 export default class App extends React.Component {
-  setRef = ref => {
-    this.table = ref
-    window.t = ref
-  }
-
-  scroll = () => this.table.scrollToRow(100, 'auto')
+  setRef = ref => (this.table = ref)
 
   render() {
     return (
       <>
-        <Button onClick={this.scroll}>scrollToRow(100, 'auto')</Button>
+        <Button onClick={() => this.table.scrollToRow(100, 'auto')}>
+          scrollToRow(100, 'auto')
+        </Button>
         <Button onClick={() => this.table.scrollToRow(200, 'start')}>
           scrollToRow(200, 'start')
         </Button>

--- a/website/src/examples/scroll-to.js
+++ b/website/src/examples/scroll-to.js
@@ -1,0 +1,47 @@
+const columns = generateColumns(10)
+const data = generateData(columns, 500)
+
+const Button = styled.button`
+  padding: 4px 8px;
+  margin: 10px;
+`
+
+export default class App extends React.Component {
+  setRef = ref => {
+    this.table = ref
+    window.t = ref
+  }
+
+  scroll = () => this.table.scrollToRow(100, 'auto')
+
+  render() {
+    return (
+      <>
+        <Button onClick={this.scroll}>scrollToRow(100, 'auto')</Button>
+        <Button onClick={() => this.table.scrollToRow(200, 'start')}>
+          scrollToRow(200, 'start')
+        </Button>
+        <Button onClick={() => this.table.scrollToRow(300, 'center')}>
+          scrollToRow(300, 'center')
+        </Button>
+        <Button onClick={() => this.table.scrollToRow(400, 'end')}>
+          scrollToRow(400, 'end')
+        </Button>
+        <Button onClick={() => this.table.scrollToLeft(400)}>
+          scrollToLeft(400)
+        </Button>
+        <Button onClick={() => this.table.scrollToTop(400)}>
+          scrollToTop(400)
+        </Button>
+        <Button
+          onClick={() =>
+            this.table.scrollToPosition({ scrollLeft: 200, scrollTop: 2000 })
+          }
+        >
+          {'scrollToPosition({ scrollLeft: 200, scrollTop: 2000 })'}
+        </Button>
+        <Table ref={this.setRef} fixed columns={columns} data={data} />
+      </>
+    )
+  }
+}


### PR DESCRIPTION
fix the issue described in #76 , that's a regression introduced in #73, the following is the I left for the initial fix to move the methods in a setTimeout:

    // if the table is in `fixed` mode, it could be scrolled horizontally, in that case,
    // the horizontal scroll position would be unexpected if the `align` is not `start`,
    // so we reset the horizontal scroll to the previous value in that case,
    // and the two scroll methods would be batched on event callback, and the `onScroll` event will be called after that,
    // then it will be reset to the original position as the `this._scroll` is not synced to the new state,
    // so we put them in a `setTimeout` to make `onScroll` be called before we set the horizontal position.

but actually it will break in concurrent mode as the batched behavior is not only for event callback, but we are not concurrent mode ready as we used `cWRP`, so the current workaround is OK, for long term we probably have to implement my own align logic to solve the problem

UPDATE: just read the source code of `react-window`, we don't need to implement our own align logic anymore