### PR TITLE
fix: unflatten should not override the existing children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- fix: `unflatten` should not override the existing children
+
 ## v1.8.0 (2019-08-30)
 
 - feat: remove deprecated lifecycles for concurrent mode ready

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,7 +65,11 @@ export function unflatten(array, rootId = null, dataKey = 'id', parentKey = 'par
     const id = item[dataKey];
     const parentId = item[parentKey];
 
-    if (!childrenMap[id]) childrenMap[id] = [];
+    if (Array.isArray(item.children)) {
+      childrenMap[id] = item.children.concat(childrenMap[id] || []);
+    } else if (!childrenMap[id]) {
+      childrenMap[id] = [];
+    }
     item.children = childrenMap[id];
 
     if (parentId !== undefined && parentId !== rootId) {


### PR DESCRIPTION
the case is we unflatten the data once, and then group(unflatten) the data in some rule, we should keep the former tree structure as well