### PR TITLE
feat: add container to arguments passed to `dataGetter`

### DIFF
--- a/src/BaseTable.tsx
+++ b/src/BaseTable.tsx
@@ -889,7 +889,7 @@ export default class BaseTable extends React.PureComponent<BaseTableProps, BaseT
     const TableCell = this._getComponent('TableCell');
 
     const cellData = dataGetter
-      ? dataGetter({ columns, column, columnIndex, rowData, rowIndex })
+      ? dataGetter({ columns, column, columnIndex, rowData, rowIndex, container: this })
       : getValue(rowData, dataKey);
     const cellProps = { isScrolling, cellData, columns, column, columnIndex, rowData, rowIndex, container: this };
     const cell = renderElement(cellRenderer || <TableCell className={this._prefixClass('row-cell-text')} />, cellProps);


### PR DESCRIPTION
This PR adds the `container` property to the argument list in the `dataGetter` call in the same as the `cellRenderer` call.

I would like to be able to access custom props that are passed to the container in the data getter function. Currently this is supported in the `cellRenderer` however we don't need the power of the that function (cell rendering for us is taken care of elsewhere).