### PR TITLE
fix: rowHeight is not calculated correctly with frozen columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- fix: rowHeight is not calculated correctly with frozen columns
+
 ## v1.10.0 (2020-06-22)
 
 - feat: add `estimatedRowHeight` to support dynamic row height

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -113,10 +113,10 @@ class TableRow extends React.PureComponent {
 
   _measureHeight() {
     if (this.ref) {
-      const { rowKey, onRowHeightMeasured, rowIndex } = this.props;
+      const { rowKey, onRowHeightMeasured, rowIndex, columns } = this.props;
       const height = this.ref.getBoundingClientRect().height;
       this.setState({ measured: true }, () => {
-        onRowHeightMeasured(rowKey, height, rowIndex);
+        onRowHeightMeasured(rowKey, height, rowIndex, !columns[0].__placeholder__ && columns[0].frozen);
       });
     }
   }


### PR DESCRIPTION
fix an issue mentioned here https://github.com/Autodesk/react-base-table/pull/170#issuecomment-647873148

@jamesonhill FYI, I thought the buffer is a genius idea to merge the heights from different tables, but it seems using separate maps to cache is much safer