### PR TITLE
Fix column widths reset in dynamic mode

### DIFF
--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -741,7 +741,13 @@ class BaseTable extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { data, height, maxHeight } = this.props;
+    const { data, height, maxHeight, columns, estimatedRowHeight } = this.props;
+    if (
+      estimatedRowHeight &&
+      columns.some(col => col.hidden !== prevProps.columns.find(x => x.key === col.key).hidden)
+    ) {
+      this.resetColumnWidthCache();
+    }
     if (data !== prevProps.data) {
       this._lastScannedRowIndex = -1;
       this._hasDataChangedSinceEndReached = true;

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -744,7 +744,10 @@ class BaseTable extends React.PureComponent {
     const { data, height, maxHeight, columns, estimatedRowHeight } = this.props;
     if (
       estimatedRowHeight &&
-      columns.some(col => col.hidden !== prevProps.columns.find(x => x.key === col.key).hidden)
+      columns.some(col => {
+        const prevCol = prevProps.columns.find(x => x.key === col.key);
+        return prevCol && prevCol.hidden !== col.hidden;
+      })
     ) {
       this.resetColumnWidthCache();
     }


### PR DESCRIPTION
This is intended to fix this issue: https://github.com/Autodesk/react-base-table/issues/177
The grid width is not updating when columns are hidden in dynamic mode. This adds a check to resetColumnWidth cache if `column.hidden` changes for a column.