### PR TITLE
fix: getTotalRowsHeight could be different before/after render in dynamic mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- fix: `getTotalRowsHeight` could be different before/after render in dynamic mode
+
 ## v1.10.5 (2020-07-10)
 
 - chore: do not clear row height cache automatically

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -742,7 +742,9 @@ class BaseTable extends React.PureComponent {
     this._maybeScrollbarPresenceChange();
 
     if (estimatedRowHeight) {
-      // have to wrap with setTimeout or we would still get the previous value
+      // we have to wrap with setTimeout or we would still get the previous value,
+      // as we reset the inner components directly instead of update the table itself after row heights measured,
+      // so `componentDidUpdate` won't be invoked after that
       setTimeout(() => {
         if (this.getTotalRowsHeight() !== this._totalRowsHeight) {
           this.forceUpdate();

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -742,6 +742,7 @@ class BaseTable extends React.PureComponent {
     this._maybeScrollbarPresenceChange();
 
     if (estimatedRowHeight) {
+      // have to wrap with setTimeout or we would still get the previous value
       setTimeout(() => {
         if (this.getTotalRowsHeight() !== this._totalRowsHeight) {
           this.forceUpdate();

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -741,11 +741,13 @@ class BaseTable extends React.PureComponent {
     }
     this._maybeScrollbarPresenceChange();
 
-    setTimeout(() => {
-      if (estimatedRowHeight && this.getTotalRowsHeight() !== this._totalRowsHeight) {
-        this.forceUpdate();
-      }
-    });
+    if (estimatedRowHeight) {
+      setTimeout(() => {
+        if (this.getTotalRowsHeight() !== this._totalRowsHeight) {
+          this.forceUpdate();
+        }
+      });
+    }
   }
 
   _prefixClass(className) {

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -692,6 +692,7 @@ class BaseTable extends React.PureComponent {
     }
     // should be after `this._data` assigned
     this._calcScrollbarSizes();
+    this._totalRowsHeight = this.getTotalRowsHeight();
 
     const containerStyle = {
       ...style,
@@ -729,7 +730,7 @@ class BaseTable extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { data, height, maxHeight } = this.props;
+    const { data, height, maxHeight, estimatedRowHeight } = this.props;
     if (data !== prevProps.data) {
       this._lastScannedRowIndex = -1;
       this._hasDataChangedSinceEndReached = true;
@@ -739,6 +740,12 @@ class BaseTable extends React.PureComponent {
       this._maybeCallOnEndReached();
     }
     this._maybeScrollbarPresenceChange();
+
+    setTimeout(() => {
+      if (estimatedRowHeight && this.getTotalRowsHeight() !== this._totalRowsHeight) {
+        this.forceUpdate();
+      }
+    });
   }
 
   _prefixClass(className) {


### PR DESCRIPTION
fix #199 

the bug also happens with `maxHeight`, the cause is that `getTotalRowsHeight` would be call before rendered, so the height is the previous value of `GridTable`