### PR TITLE
fix: add types folder into packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-base-table",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "a react table component to display large data set with high performance and flexibility",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -8,6 +8,7 @@
   "files": [
     "lib/",
     "es/",
+    "types/",
     "styles.css"
   ],
   "author": "Neo Nie <nihgwu@live.com>",


### PR DESCRIPTION
Right now the typescript d.ts file is not packaged into the npm bundle, we should include it :P