### PR TITLE
feat: add the ability to pass function in estimatedRowHeight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- feat: add the ability to pass function in `estimatedRowHeight` to determine the initial height of rows
+
 ## v1.11.3 (2020-08-24)
 
 - fix: remove propTypes for Column.key

--- a/src/GridTable.js
+++ b/src/GridTable.js
@@ -5,6 +5,7 @@ import { FixedSizeGrid, VariableSizeGrid } from 'react-window';
 import memoize from 'memoize-one';
 
 import Header from './TableHeader';
+import { getEstimatedTotalRowsHeight } from './utils';
 
 /**
  * A wrapper of the Grid for internal only
@@ -23,6 +24,7 @@ class GridTable extends React.PureComponent {
       if (!this.props.estimatedRowHeight) return;
       this.bodyRef && this.bodyRef.resetAfterColumnIndex(0, false);
     });
+    this._getEstimatedTotalRowsHeight = memoize(getEstimatedTotalRowsHeight);
 
     this.renderRow = this.renderRow.bind(this);
   }
@@ -59,7 +61,9 @@ class GridTable extends React.PureComponent {
     const { data, rowHeight, estimatedRowHeight } = this.props;
 
     if (estimatedRowHeight) {
-      return (this.innerRef && this.innerRef.clientHeight) || data.length * estimatedRowHeight;
+      return (
+        (this.innerRef && this.innerRef.clientHeight) || this._getEstimatedTotalRowsHeight(data, estimatedRowHeight)
+      );
     }
     return data.length * rowHeight;
   }
@@ -114,7 +118,7 @@ class GridTable extends React.PureComponent {
           width={width}
           height={Math.max(height - headerHeight - frozenRowsHeight, 0)}
           rowHeight={estimatedRowHeight ? getRowHeight : rowHeight}
-          estimatedRowHeight={estimatedRowHeight}
+          estimatedRowHeight={typeof estimatedRowHeight === 'function' ? undefined : estimatedRowHeight}
           rowCount={data.length}
           overscanRowCount={overscanRowCount}
           columnWidth={estimatedRowHeight ? this._getBodyWidth : bodyWidth}
@@ -198,7 +202,7 @@ GridTable.propTypes = {
   headerWidth: PropTypes.number.isRequired,
   bodyWidth: PropTypes.number.isRequired,
   rowHeight: PropTypes.number.isRequired,
-  estimatedRowHeight: PropTypes.number,
+  estimatedRowHeight: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   getRowHeight: PropTypes.func,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,
   data: PropTypes.array.isRequired,

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -183,7 +183,7 @@ TableRow.propTypes = {
   rowRenderer: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   cellRenderer: PropTypes.func,
   expandIconRenderer: PropTypes.func,
-  estimatedRowHeight: PropTypes.number,
+  estimatedRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   getIsResetting: PropTypes.func,
   onRowHover: PropTypes.func,
   onRowExpand: PropTypes.func,

--- a/src/utils.js
+++ b/src/utils.js
@@ -251,3 +251,9 @@ export function removeClassName(el, className) {
     el.className = el.className.replace(new RegExp(`(?:^|\\s)${className}(?!\\S)`, 'g'), '');
   }
 }
+
+export function getEstimatedTotalRowsHeight(data, estimatedRowHeight) {
+  return typeof estimatedRowHeight === 'function'
+    ? data.reduce((height, rowData, rowIndex) => height + estimatedRowHeight({ rowData, rowIndex }), 0)
+    : data.length * estimatedRowHeight;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -208,8 +208,15 @@ declare module 'react-base-table' {
     rowHeight?: number;
     /**
      * Estimated row height, the real height will be measure dynamically according to the content
+     * The callback is of the shape of `({ rowData, rowIndex }) => number`
      */
-    estimatedRowHeight?: number;
+    estimatedRowHeight?: CallOrReturn<
+      number,
+      {
+        rowData: T;
+        rowIndex: number;
+      }
+    >;
     /**
      * The height of the table header, set to 0 to hide the header, could be an array to render multi headers.
      */


### PR DESCRIPTION
This PR makes possible to pass in `estimatedRowHeight` property a function that called for each row to get initial height of row. This can help to fix "jumping" effect on first rendering when height of rows are known (possible fix #227)