### PR TITLE
chore: update README.md to emphasize the importance of importing styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ yarn add react-base-table
 ```js
 import BaseTable, { Column } from 'react-base-table'
 import 'react-base-table/styles.css'
-
-...
+// Important: if you fail to import react-base-table/styles.css then 
+// BaseTable will not render as advertised in the included examples.
+// For advanced styling see link below:
+// https://github.com/Autodesk/react-base-table/blob/master/docs/advance.md
+ ...
 <BaseTable data={data} width={600} height={400}>
   <Column key="col0" dataKey="col0" width={100} />
   <Column key="col1" dataKey="col1" width={100} />
@@ -32,7 +35,7 @@ import 'react-base-table/styles.css'
 ...
 ```
 
-> __Important:__ if you fail to import `react-base-table/styles.css` then `BaseTable` will not render as advertised in the included examples. 
+
 
 Learn more at the [website](https://autodesk.github.io/react-base-table/)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ yarn add react-base-table
 ```
 
 ## Usage
-i
+
 ```js
 import BaseTable, { Column } from 'react-base-table'
 import 'react-base-table/styles.css'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ yarn add react-base-table
 ```
 
 ## Usage
-
+i
 ```js
 import BaseTable, { Column } from 'react-base-table'
 import 'react-base-table/styles.css'
@@ -31,6 +31,8 @@ import 'react-base-table/styles.css'
 </BaseTable>
 ...
 ```
+
+> __Important:__ if you fail to import `react-base-table/styles.css` then `BaseTable` will not render as advertised in the included examples. 
 
 Learn more at the [website](https://autodesk.github.io/react-base-table/)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import 'react-base-table/styles.css'
 // Important: if you fail to import react-base-table/styles.css then 
 // BaseTable will not render as advertised in the included examples.
 // For advanced styling see link below:
-// https://github.com/Autodesk/react-base-table/blob/master/docs/advance.md
+// https://github.com/Autodesk/react-base-table#advance
  ...
 <BaseTable data={data} width={600} height={400}>
   <Column key="col0" dataKey="col0" width={100} />
@@ -34,8 +34,6 @@ import 'react-base-table/styles.css'
 </BaseTable>
 ...
 ```
-
-
 
 Learn more at the [website](https://autodesk.github.io/react-base-table/)
 


### PR DESCRIPTION
- included message in README to emphasize importance of importing CSS classes as defined in `react-base-table/styles.css` in order for `BaseTable` to render as advertised in examples