### PR TITLE
fix: change propTypes for BaseTable.components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT VERSION
 
+- fix: change propTypes for `BaseTable.components`
+
 ## v1.12.0 (2020-10-11)
 
 - feat: add the ability to pass function in `estimatedRowHeight` to determine the initial height of rows

--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -1306,10 +1306,10 @@ BaseTable.propTypes = {
    * A object for the custom components, like `ExpandIcon` and `SortIndicator`
    */
   components: PropTypes.shape({
-    TableCell: PropTypes.func,
-    TableHeaderCell: PropTypes.func,
-    ExpandIcon: PropTypes.func,
-    SortIndicator: PropTypes.func,
+    TableCell: PropTypes.elementType,
+    TableHeaderCell: PropTypes.elementType,
+    ExpandIcon: PropTypes.elementType,
+    SortIndicator: PropTypes.elementType,
   }),
 };
 


### PR DESCRIPTION
This PR fix prop-types warnings when using custom components, defined as classes.