### PR TITLE
fix: render footer below table

### DIFF
--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -724,13 +724,13 @@ class BaseTable extends React.PureComponent {
     });
     return (
       <div ref={this._setContainerRef} className={cls} style={containerStyle}>
-        {this.renderFooter()}
         {this.renderMainTable()}
         {this.renderLeftTable()}
         {this.renderRightTable()}
         {this.renderResizingLine()}
         {this.renderEmptyLayer()}
         {this.renderOverlay()}
+        {this.renderFooter()}
       </div>
     );
   }


### PR DESCRIPTION
This allows for better keyboard navigation when rendering focusable content in the footer. The current location leads to buttons rendered in the table footer being tabbed to before tabbing to the table. 