### PR TITLE
Fix dynamic row height calculation with scaled parent element

### DIFF
--- a/src/BaseTable.js
+++ b/src/BaseTable.js
@@ -317,7 +317,7 @@ class BaseTable extends React.PureComponent {
   }
 
   renderRow({ isScrolling, columns, rowData, rowIndex, style }) {
-    const { rowClassName, rowRenderer, rowEventHandlers, expandColumnKey, estimatedRowHeight } = this.props;
+    const { rowClassName, rowRenderer, rowEventHandlers, expandColumnKey, estimatedRowHeight, scale } = this.props;
 
     const rowClass = callOrReturn(rowClassName, { columns, rowData, rowIndex });
     const extraProps = callOrReturn(this.props.rowProps, { columns, rowData, rowIndex });
@@ -357,6 +357,7 @@ class BaseTable extends React.PureComponent {
       // for fixed table, we need to sync the hover state across the inner tables
       onRowHover: hasFrozenColumns ? this._handleRowHover : null,
       onRowHeightChange: hasFrozenColumns ? this._handleFrozenRowHeightChange : this._handleRowHeightChange,
+      scale,
     };
 
     return <TableRow {...rowProps} />;
@@ -1294,6 +1295,11 @@ BaseTable.propTypes = {
     ExpandIcon: PropTypes.func,
     SortIndicator: PropTypes.func,
   }),
+
+  /**
+   * Scale factor applied to a parent element
+   */
+  scale: PropTypes.number,
 };
 
 export default BaseTable;

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -115,8 +115,13 @@ class TableRow extends React.PureComponent {
   _measureHeight(initialMeasure) {
     if (!this.ref) return;
 
-    const { style, rowKey, onRowHeightChange, rowIndex, columns } = this.props;
-    const height = this.ref.getBoundingClientRect().height;
+    const { style, rowKey, onRowHeightChange, rowIndex, columns, scale } = this.props;
+    let height = this.ref.getBoundingClientRect().height;
+
+    if (scale && scale > 0 && scale < 1) {
+      height = height / scale;
+    }
+
     this.setState({ measured: true }, () => {
       if (initialMeasure || height !== style.height)
         onRowHeightChange(rowKey, height, rowIndex, columns[0] && !columns[0].__placeholder__ && columns[0].frozen);
@@ -189,6 +194,7 @@ TableRow.propTypes = {
   onRowExpand: PropTypes.func,
   onRowHeightChange: PropTypes.func,
   tagName: PropTypes.elementType,
+  scale: PropTypes.number,
 };
 
 export default TableRow;

--- a/website/src/examples/dynamic-row-heights.js
+++ b/website/src/examples/dynamic-row-heights.js
@@ -191,17 +191,34 @@ export default class App extends React.Component {
         >
           Add item to top
         </button>
-        <Table
-          fixed
-          selectable
-          columns={
-            !!this.state.toggle ? this.columns.slice(0, 4) : this.columns
-          }
-          estimatedRowHeight={40}
-          data={data}
-          sortBy={sortBy}
-          onColumnSort={this.onColumnSort}
+        <input
+          placeholder="Scale factor"
+          onChange={e => {
+            if (parseFloat(e.target.value)) {
+              this.setState({ scale: parseFloat(e.target.value) })
+            }
+          }}
         />
+        <div
+          style={
+            this.state.scale
+              ? { transform: `scale(${this.state.scale})` }
+              : undefined
+          }
+        >
+          <Table
+            fixed
+            selectable
+            columns={
+              !!this.state.toggle ? this.columns.slice(0, 4) : this.columns
+            }
+            estimatedRowHeight={40}
+            data={data}
+            sortBy={sortBy}
+            onColumnSort={this.onColumnSort}
+            scale={this.state.scale}
+          />
+        </div>
       </>
     )
   }


### PR DESCRIPTION
If there is `transform: scale(someNumber)` applied anywhere in the parent element tree, the dynamic row calculation will be wrong for values less than zero.

Example: https://autodesk.github.io/react-base-table/playground#MYewdgzgLgBKA2BXAtpGBeGBzApmHATgIZQ4DCISqEAFAIwAMAlAFCiSwAmJRG2ehEjgAiPGghSQANDABMDBa3bQYAMwIgAXnlFRemXPmKldRcZUkQZdGQHJ1WvAFoNAdye3WbcCtUBLAA8cTgoqNEwJagA6ZCIABxpzMJlIsABJME4cAKYMAD4YAG8WGBh4HFgHbTASmD9VGCTJDKyAmAAeGDpcqrw+UMkogDENauE-AhxgKD9wKIAZAFEhgBVa+sbUluyYAoAOHtG+zAHUYaOwccnp2bAogCU0gHEACTXSyahEAjAimCiAakZL1fgBfFigrzKWDZOJETKnMAAaRwAE8+LZUk4GLYWCwAPT4mBETicGAQEDIHDkxAAIzqpGQEBYqhABEa5Vgfj4DAA3HUOl0FPy-ABqUW5Yqlbh6KJxRAQAAWNClpX+AJlRAA2gwALpSWqlPycABcMAABgASQqanW6qLG0FOCB0pzWvyg80GtUwOGTMBQNKmmC2vUOzjetVa2HwkIWVAo1G6s3mgDKdJg7s9kchtU1coVytVpQBUVtsn1hrqwatNp4Wor4adLtpbsKHq9Vb9eEDwfL9uNkdK0YCcIR8eRaOTFvT9KzndKuelPALSpVVdL-aH1ZT1v7TedrpbbY72+7AaDu7regbA84zdd8+3I7HcbCienadds8z7eztVzcFvA4GAoEmEQeD4RAwFUeASFIMAaE1LxYTZLgcFUIhEHgWAaFydAChoWp2k4PwADdySgVFynQQpClA4hIFZAhkDNWwIGAIhyhoBgogAViYWwYFBUE8mIlYiFpcoq38IJOCrVIIFo2TgkRCBwR9TVaLAnAIL0DS1RBUxlIuUwDNKGNx3fNFaMst9JETcyYBwaA-FiUhOHuEBXBeHA-CwRUoFogA2BgDPxMTSnafFSLIsTWCAA