### PR TITLE
fix: table crash on setting scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NEXT VERSION
 
+## v1.13.2 (2022-05-14)
+
+- fix: error imported by optimization render task
+
 ## v1.13.1 (2022-05-14)
 
 - fix: optimization render task performance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-base-table",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "a react table component to display large data set with high performance and flexibility",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/TableHeader.js
+++ b/src/TableHeader.js
@@ -11,11 +11,9 @@ class TableHeader extends React.PureComponent {
   }
 
   scrollTo(offset) {
-    if (this.headerRef) {
-      requestAnimationFrame(() => {
-        this.headerRef.scrollLeft = offset;
-      });
-    }
+    requestAnimationFrame(() => {
+      if (this.headerRef) this.headerRef.scrollLeft = offset;
+    });
   }
 
   renderHeaderRow(height, index) {


### PR DESCRIPTION
The table heade ref may be undefined on the requestAnimationFrame call

E.g. Uncaught TypeError: Cannot set properties of null (setting 'scrollLeft')

The issue imported from the change at https://github.com/Autodesk/react-base-table/pull/348