### PR TITLE
Stop using React.Key in typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,7 +15,7 @@ declare module 'react-base-table' {
     /**
      * Unique key for each column
      */
-    key: React.Key;
+    key: string | number;
     /**
      * Class name for the column cell
      */
@@ -385,7 +385,7 @@ declare module 'react-base-table' {
      * The sort state for the table, will be ignored if `sortState` is set
      */
     sortBy?: {
-      key: React.Key;
+      key: string | number;
       order: SortOrder;
     };
     /**
@@ -400,13 +400,13 @@ declare module 'react-base-table' {
      * ```
      */
     sortState?: {
-      [key in React.Key]: SortOrder;
+      [key in string | number]: SortOrder;
     };
     /**
      * A callback function for the header cell click event
      * The handler is of the shape of `({ column, key, order }) => *`
      */
-    onColumnSort?: (args: { column: ColumnShape<T>; key: React.Key; order: SortOrder }) => void;
+    onColumnSort?: (args: { column: ColumnShape<T>; key: string | number; order: SortOrder }) => void;
     /**
      * A callback function when resizing the column width
      * The handler is of the shape of `({ column, width }) => *`


### PR DESCRIPTION
The typing for React.key has been changed to include 'bigint' (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66723). React Team recommends not using this type for our own keys (specifically for object indexing types - see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66749#discussioncomment-7059100). Attempting to use it as we do (specifically in `sortState`) causes an error when using @types/react@18, since typescript doesn't allow bigint as index type. Though this library doesn't officially support React 18, hardcoding the old type of string | number will at least prevent consumers' typechecking from breaking if they do use React 18.