### PR TITLE
feat: support custom TableHeaderRow via components prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.1.0 (2026-04-16)
+
+- feat: add `TableHeaderRow` to customizable `components` prop, allowing custom header row rendering
+
 ## v2.0.0 (2026-04-16)
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-base-table",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "a react table component to display large data set with high performance and flexibility",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/BaseTable.tsx
+++ b/src/BaseTable.tsx
@@ -58,6 +58,7 @@ const getContainerStyle = (width: number, maxWidth: number, height: number): Rea
 const DEFAULT_COMPONENTS: Record<string, React.ComponentType<any>> = {
   TableCell,
   TableHeaderCell,
+  TableHeaderRow,
   ExpandIcon,
   SortIndicator,
 };
@@ -862,8 +863,8 @@ class BaseTable extends React.PureComponent<BaseTableProps, BaseTableState> {
       expandColumnKey: this.props.expandColumnKey,
       expandIcon: this._getComponent('ExpandIcon'),
     };
-
-    return <TableHeaderRow {...headerProps} />;
+    const TableHeaderRowComp = this._getComponent('TableHeaderRow');
+    return <TableHeaderRowComp {...headerProps} />;
   }
 
   renderHeaderCell({ columns, column, columnIndex, headerIndex, expandIcon }: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,7 @@ export type SortState = Record<string, SortOrderValue>;
 export interface TableComponents {
   TableCell?: React.ElementType;
   TableHeaderCell?: React.ElementType;
+  TableHeaderRow?: React.ElementType;
   ExpandIcon?: React.ElementType;
   SortIndicator?: React.ElementType;
 }


### PR DESCRIPTION
Add TableHeaderRow to the customizable `components` prop, allowing consumers to replace the default header row renderer.

Bump version to 2.1.0 to fix https://github.com/Autodesk/react-base-table/pull/310