### PR TITLE
chore: remove deprecated babel proposal plugins

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,8 +10,6 @@
     "@babel/preset-typescript",
   ],
   "plugins": [
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-runtime"
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,6 @@
     "@babel/cli": "^7.28.6",
     "@babel/core": "^7.29.0",
     "@babel/eslint-parser": "^7.28.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/plugin-transform-runtime": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.28.5",


### PR DESCRIPTION
Remove deprecated Babel proposal plugins                                                                                 

`@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-object-rest-spread` are deprecated. Both transforms are    already included in `@babel/preset-env`, so the explicit plugins are redundant.                                           
  
Testing: ran npm run build:js, npm run build:es, and npm test — all pass (22/22 tests).                              

Issue:
```
 WARN  deprecated @babel/plugin-proposal-object-rest-spread@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
 WARN  deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
```